### PR TITLE
feat: add ability to use ldap auth provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 
 
 release/
+.secrets.env

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ vault-seed:
 	#################################
 
 	VAULT_ADDR=http://localhost:8200 \
-		VAULT_TOKEN=vela \
+		VAULT_TOKEN=superSecretToken \
 		vault write secret/my-secret foo=bar
 
 docker-run:
@@ -70,9 +70,12 @@ docker-run:
 		--network secret-vault_vault \
 		-e PARAMETER_LOG_LEVEL \
 		-e PARAMETER_ADDR \
-		-e PARAMETER_TOKEN \
-		-e PARAMETER_PATH \
+		-e PARAMETER_AUTH_METHOD \
 		-e PARAMETER_KEYS \
+		-e PARAMETER_PATH \
+		-e PARAMETER_PASSWORD \
+		-e PARAMETER_TOKEN \
+		-e PARAMETER_USERNAME \
 		secret-vault:local	
 
 docker-example:
@@ -84,7 +87,10 @@ docker-example:
 		--network secret-vault_vault \
 		-e PARAMETER_LOG_LEVEL=trace \
 		-e PARAMETER_ADDR=http://vault:8200 \
-		-e PARAMETER_TOKEN=vela \
+		-e PARAMETER_AUTH_METHOD=token \
+		-e PARAMETER_KEYS=foo \		
 		-e PARAMETER_PATH=secret/my-secret  \
-		-e PARAMETER_KEYS=foo \
+		-e PARAMETER_PASSWORD=superSecretPassword  \
+		-e PARAMETER_TOKEN=superSecretToken \
+		-e PARAMETER_USERNAME=myusername \
 		secret-vault:local

--- a/cmd/secret-vault/config_test.go
+++ b/cmd/secret-vault/config_test.go
@@ -6,34 +6,79 @@ package main
 
 import (
 	"testing"
+
+	"github.com/go-vela/secret-vault/vault"
 )
 
 func TestVault_Config_New(t *testing.T) {
 	// setup types
-	c := &Config{
-		Addr:  "https://myvault.com/",
-		Token: "superSecretAPIKey",
+	tests := []struct {
+		config *Config
+		err    error
+	}{
+		{ // valid config with token auth method
+			config: &Config{
+				Addr:       "https://myvault.com/",
+				AuthMethod: vault.TokenAuthMethod,
+				Token:      "superSecretAPIKey",
+			},
+			err: nil,
+		},
+		// TODO: investigate how to put mock vault in a mode with a fake LDAP provider
+		// { // valid config with ldap auth method
+		// 	config: &Config{
+		// 		Addr:       "https://myvault.com/",
+		// 		AuthMethod: vault.LDAPAuthMethod,
+		// 		Password:   "superSecretPassword",
+		// 		Username:   "myusername",
+		// 	},
+		// 	err: nil,
+		// },
 	}
 
-	got, err := c.New()
-	if err != nil {
-		t.Errorf("New returned err: %v", err)
-	}
+	// run test
+	for _, test := range tests {
+		got, err := test.config.New()
+		if err != nil {
+			t.Errorf("New returned err: %v", err)
+		}
 
-	if got == nil {
-		t.Errorf("New is nil")
+		if got == nil {
+			t.Errorf("New is nil")
+		}
 	}
 }
 
 func TestVault_Config_Validate(t *testing.T) {
 	// setup types
-	c := &Config{
-		Addr:  "https://myvault.com/",
-		Token: "superSecretAPIKey",
+	tests := []struct {
+		config *Config
+		err    error
+	}{
+		{ // valid config with token auth method
+			config: &Config{
+				Addr:       "https://myvault.com/",
+				AuthMethod: vault.TokenAuthMethod,
+				Token:      "superSecretAPIKey",
+			},
+			err: nil,
+		},
+		{ // valid config with ldap auth method
+			config: &Config{
+				Addr:       "https://myvault.com/",
+				AuthMethod: vault.LDAPAuthMethod,
+				Password:   "superSecretPassword",
+				Username:   "myusername",
+			},
+			err: nil,
+		},
 	}
 
-	err := c.Validate()
-	if err != nil {
-		t.Errorf("Validate returned err: %v", err)
+	// run test
+	for _, test := range tests {
+		err := test.config.Validate()
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
 	}
 }

--- a/cmd/secret-vault/main.go
+++ b/cmd/secret-vault/main.go
@@ -77,8 +77,11 @@ func run(c *cli.Context) error {
 	// setup plugin
 	p := Plugin{
 		Config: &Config{
-			Addr:  c.String("config.addr"),
-			Token: c.String("config.token"),
+			Addr:       c.String("config.addr"),
+			AuthMethod: c.String("config.auth-method"),
+			Password:   c.String("config.password"),
+			Token:      c.String("config.token"),
+			Username:   c.String("config.username"),
 		},
 		Read: &Read{
 			Path: c.String("path"),
@@ -89,7 +92,7 @@ func run(c *cli.Context) error {
 	// validate the plugin configuration
 	err := p.Validate()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// execute the plugin

--- a/cmd/secret-vault/plugin_test.go
+++ b/cmd/secret-vault/plugin_test.go
@@ -35,8 +35,6 @@ func TestVault_Plugin_Validate(t *testing.T) {
 			},
 			err: nil,
 		},
-<<<<<<< HEAD
-=======
 		{ // success with ldap config and read action
 			plugin: &Plugin{
 				Config: &Config{
@@ -52,7 +50,6 @@ func TestVault_Plugin_Validate(t *testing.T) {
 			},
 			err: nil,
 		},
->>>>>>> 6fc7396... feat: add ability to read from vault with ldap provider
 	}
 
 	// run test

--- a/cmd/secret-vault/plugin_test.go
+++ b/cmd/secret-vault/plugin_test.go
@@ -4,7 +4,11 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/go-vela/secret-vault/vault"
+)
 
 func TestVault_Plugin_Exec(t *testing.T) {
 	// TODO write this test
@@ -12,15 +16,50 @@ func TestVault_Plugin_Exec(t *testing.T) {
 
 func TestVault_Plugin_Validate(t *testing.T) {
 	// setup types
-	p := &Plugin{
-		Config: &Config{
-			Addr:  "https://myvault.com/",
-			Token: "superSecretAPIKey",
+	// setup types
+	tests := []struct {
+		plugin *Plugin
+		err    error
+	}{
+		{ // success with token config and read action
+			plugin: &Plugin{
+				Config: &Config{
+					Addr:       "https://myvault.com/",
+					AuthMethod: vault.TokenAuthMethod,
+					Token:      "superSecretAPIKey",
+				},
+				Read: &Read{
+					Path: "/path/to/secret",
+					Keys: []string{"foobar"},
+				},
+			},
+			err: nil,
 		},
+<<<<<<< HEAD
+=======
+		{ // success with ldap config and read action
+			plugin: &Plugin{
+				Config: &Config{
+					Addr:       "https://myvault.com/",
+					AuthMethod: vault.LDAPAuthMethod,
+					Password:   "superSecretPassword",
+					Username:   "myusername",
+				},
+				Read: &Read{
+					Path: "/path/to/secret",
+					Keys: []string{"foobar"},
+				},
+			},
+			err: nil,
+		},
+>>>>>>> 6fc7396... feat: add ability to read from vault with ldap provider
 	}
 
-	err := p.Validate()
-	if err != nil {
-		t.Errorf("Validate returned err: %v", err)
+	// run test
+	for _, test := range tests {
+		err := test.plugin.Validate()
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
 	}
 }

--- a/cmd/secret-vault/read_test.go
+++ b/cmd/secret-vault/read_test.go
@@ -49,5 +49,4 @@ func TestVault_Read_Validate(t *testing.T) {
 			t.Errorf("Validate returned err: %v", err)
 		}
 	}
-
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - vault
     environment:
       VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
-      VAULT_DEV_ROOT_TOKEN_ID: vela
+      VAULT_DEV_ROOT_TOKEN_ID: superSecretToken
     ports:
       - "8200:8200"
     cap_add:

--- a/vault/flag.go
+++ b/vault/flag.go
@@ -30,13 +30,23 @@ var Flags = []cli.Flag{
 		Usage:   "name of runtime driver to use",
 	},
 	&cli.StringFlag{
-		EnvVars: []string{"PARAMETER_TOKEN", "SECRET_VAULT_TOKEN", "VELA_VAULT_TOKEN", "VAULT_TOKEN"},
-		Name:    "config.token",
-		Usage:   "vault token for storing secrets",
-	},
-	&cli.StringFlag{
 		EnvVars: []string{"PARAMETER_AUTH_METHOD", "SECRET_AUTH_METHOD", "VAULT_AUTH_METHOD"},
 		Name:    "config.auth-method",
 		Usage:   "vault token for storing secrets",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"PARAMETER_PASSWORD", "SECRET_VAULT_PASSWORD", "VELA_VAULT_PASSWORD", "VAULT_PASSWORD"},
+		Name:    "config.password",
+		Usage:   "vault password for server authentication",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"PARAMETER_TOKEN", "SECRET_VAULT_TOKEN", "VELA_VAULT_TOKEN", "VAULT_TOKEN"},
+		Name:    "config.token",
+		Usage:   "vault token for server authentication",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"PARAMETER_USERNAME", "SECRET_VAULT_USERNAME", "VELA_VAULT_USERNAME", "VAULT_USERNAME"},
+		Name:    "config.username",
+		Usage:   "vault username for server authentication",
 	},
 }

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -5,35 +5,114 @@
 package vault
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/vault"
+	"github.com/sirupsen/logrus"
 )
 
-type Client struct {
-	// https://pkg.go.dev/github.com/hashicorp/vault/api?tab=doc
-	Vault *api.Client
-}
+const (
+	// LDAPAuthMethod is used for creating a client capable of LDAP authentication
+	LDAPAuthMethod = "ldap"
 
-// New returns a Secret implementation that integrates with a Vault secrets engine.
-func New(addr, token string) (*Client, error) {
-	conf := api.Config{Address: addr}
+	// TokenAuthMethod is used for creating a client capable of token authentication
+	TokenAuthMethod = "token"
+)
 
-	// create Vault client
-	c, err := api.NewClient(&conf)
-	if err != nil {
-		return nil, err
+type (
+	// client represents an internal struct for managing calls to a Vault instance
+	//
+	// Vault client docs: https://pkg.go.dev/github.com/hashicorp/vault/api?tab=doc
+	Client struct {
+		Vault *api.Client
 	}
 
-	// set Vault API token in client
-	c.SetToken(token)
+	// Setup represents the configuration necessary for
+	// creating a Vault client capable of integrating
+	// with a Vault instance.
+	Setup struct {
+		// specifies the address of the vault instances
+		Addr string
+		// specifies the authentication method to use
+		AuthMethod string
+		// specifies the password for authentication with LDAP auth method
+		Password string
+		// specifies the token for the vault instances
+		Token string
+		// specifies the username for authentication with LDAP auth method
+		Username string
+	}
+)
 
-	// return client
-	return &Client{
-		Vault: c,
-	}, nil
+var (
+	// ErrInvalidAuthMethod defines the error type when the
+	// AuthMethod provided to the client is unsupported.
+	ErrInvalidAuthMethod = errors.New("invalid auth method provided")
+
+	// LDAPUserPath defines the path the user information gets
+	// written to after success LDAP authentication
+	LDAPUserPath = "/auth/ldap/login/%s"
+)
+
+// New returns a Secret implementation that integrates with a Vault secrets engine.
+func New(s *Setup) (*Client, error) {
+	conf := &api.Config{Address: s.Addr}
+
+	// add auth method specific vault client configuration
+	switch s.AuthMethod {
+	case LDAPAuthMethod:
+		logrus.Tracef("creating vault client with %s auth method", LDAPAuthMethod)
+		// create Vault client
+		vault, err := api.NewClient(conf)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Println("I AM HERE")
+
+		// options for passing the password
+		options := map[string]interface{}{
+			"password": s.Password,
+		}
+
+		// the login path
+		path := fmt.Sprintf(LDAPUserPath, s.Username)
+
+		// call to get a user token
+		user, err := vault.Logical().Write(path, options)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get user token: %w", err)
+		}
+
+		// set Vault API token in client
+		vault.SetToken(user.Auth.ClientToken)
+
+		return &Client{Vault: vault}, nil
+	case TokenAuthMethod:
+		logrus.Tracef("creating vault client with %s auth method", TokenAuthMethod)
+
+		// create Vault client
+		vault, err := api.NewClient(conf)
+		if err != nil {
+			return nil, err
+		}
+
+		// set Vault API token in client
+		vault.SetToken(s.Token)
+
+		return &Client{Vault: vault}, nil
+	default:
+		return nil, fmt.Errorf("%s: %s (Valid auth methods: %s, %s)",
+			ErrInvalidAuthMethod,
+			s.AuthMethod,
+			LDAPAuthMethod,
+			TokenAuthMethod,
+		)
+	}
 }
 
 // NewMock returns a test unsealed Vault
@@ -55,13 +134,12 @@ func NewMock(t *testing.T) (*Client, error) {
 
 	// Create a client that talks to the server, initially authenticating with
 	// the root token.
-	conf := api.DefaultConfig()
-	conf.Address = addr
-
-	c, err := api.NewClient(conf)
+	c, err := api.NewClient(&api.Config{Address: addr})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// set Vault API token in client
 	c.SetToken(rootToken)
 
 	return &Client{

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -72,8 +72,6 @@ func New(s *Setup) (*Client, error) {
 			return nil, err
 		}
 
-		fmt.Println("I AM HERE")
-
 		// options for passing the password
 		options := map[string]interface{}{
 			"password": s.Password,


### PR DESCRIPTION
**PR Changes:**

* Update vault package to use an auth method variable for choosing the authentication provider
* Add LDAP auth provider to vault package
* Update cmd package to allow user to swap between auth methods

**Related Open PRs:**

* https://github.com/go-vela/pkg-executor/pull/41
* https://github.com/go-vela/types/pull/81