### PR TITLE
fix(ldap/auth): handle nil Auth struct when authentication fails

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -84,6 +84,11 @@ func New(s *Setup) (*Client, error) {
 			return nil, fmt.Errorf("unable to get user token: %w", err)
 		}
 
+		// vault will return a nil Auth struct with no error if path is correct but password fails
+		if user.Auth == nil {
+			return nil, fmt.Errorf("unable to set user token: authentication failed")
+		}
+
 		// set Vault API token in client
 		vault.SetToken(user.Auth.ClientToken)
 


### PR DESCRIPTION
```go
// call to get a user token
user, err := vault.Logical().Write(path, options)
if err != nil {
	return nil, fmt.Errorf("unable to get user token: %w", err)
}
```
The above call does not return an error when the path exists but the password is wrong.

This results in a panic when trying to set the Vault token in the client.

```sh
panic: runtime error: invalid memory address or nil pointer dereference
```

A simple nil check on the `Auth` struct should suffice.