### PR TITLE
fix: add panic nil check for user

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -84,7 +84,7 @@ func New(s *Setup) (*Client, error) {
 		}
 
 		// vault will return a nil Auth struct with no error if path is correct but password fails
-		if user.Auth == nil {
+		if user == nil || user.Auth == nil {
 			return nil, fmt.Errorf("unable to set user token: authentication failed")
 		}
 


### PR DESCRIPTION
fixes a nil panic when your password is wrong

```
goroutine 1 [running]: github.com/go-vela/secret-vault/vault.New(0xc000297928)
  /home/runner/work/secret-vault/secret-vault/vault/vault.go:87 +0x236 main.(*Config).New(0xc00020f6d0)
```