### PR TITLE
fix(outputs): sanitize env keys and use warning log for parse error

### DIFF
--- a/cmd/secret-vault/read.go
+++ b/cmd/secret-vault/read.go
@@ -146,12 +146,18 @@ func (r *Read) Exec(v *vault.Client) error {
 		// godotenv has a Write, but for testing it will not write to a memory map FS
 		content, err := godotenv.Marshal(outputs)
 		if err != nil {
-			return err
+			logrus.Warnf("error marshaling secret values to outputs file. values will not be masked if accidentally logged.")
+
+			//nolint:nilerr // error string can contain sensitive information
+			return nil
 		}
 
 		err = a.WriteFile(outputsPath, []byte(content), 0600)
 		if err != nil {
-			return err
+			logrus.Warnf("error writing secret values to outputs file. values will not be masked if accidentally logged.")
+
+			//nolint:nilerr // error string can contain sensitive information
+			return nil
 		}
 	}
 

--- a/cmd/secret-vault/read_test.go
+++ b/cmd/secret-vault/read_test.go
@@ -41,7 +41,9 @@ func TestVault_Read_Exec(t *testing.T) {
 	// initialize vault with test data
 	//nolint: errcheck // error check not needed
 	vault.Vault.Logical().Write(source, map[string]interface{}{
-		"secret": "bar",
+		"secret":             "bar",
+		"dash-secret":        "baz",
+		"crazy??//!.#secret": "bazzy",
 	})
 
 	err := r.Exec(vault)
@@ -76,7 +78,15 @@ func TestVault_Read_Exec(t *testing.T) {
 	}
 
 	if envMap["VELA_SECRETS_FOOBAR_MY_SECRET"] != "bar" {
-		t.Errorf("Exec is %v, want %v", envMap["foobar_foobar2_secret"], "bar")
+		t.Errorf("Exec is %v, want %v", envMap["VELA_SECRETS_FOOBAR_MY_SECRET"], "bar")
+	}
+
+	if envMap["VELA_SECRETS_FOOBAR_DASH_SECRET"] != "baz" {
+		t.Errorf("Exec is %v, want %v", envMap["VELA_SECRETS_FOOBAR_DASH_SECRET"], "baz")
+	}
+
+	if envMap["VELA_SECRETS_FOOBAR_CRAZY_____._SECRET"] != "bazzy" {
+		t.Errorf("Exec is %v, want %v", envMap["VELA_SECRETS_FOOBAR_CRAZY_____._SECRET"], "bazzy")
 	}
 }
 


### PR DESCRIPTION
Use the godotenv library's determination of valid characters `[A-Za-z0-9_.]` for the environment key. Also do not log the initial parse error as if it's invalid, the error will log all the contents of the map.